### PR TITLE
Add options to checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add to your `:plugins`, most likely in your application's `:dev`
 profile.
 
 ``` clj
-[whitespace-linter "0.1.0"]
+[jcf/whitespace-linter "0.1.1"]
 ```
 
 To lint all files in your `:source-paths` and `:test-paths` run with

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject jcf/whitespace-linter "0.1.0"
+(defproject jcf/whitespace-linter "0.1.1-SNAPSHOT"
   :description "Finds the wrong kind of whitespace in a directory of files"
   :url "https://github.com/jcf/whitespace-linter"
   :license {:name "Eclipse Public License"

--- a/test/whitespace_linter/check_test.clj
+++ b/test/whitespace_linter/check_test.clj
@@ -11,41 +11,53 @@
 
 (deftest test-hard-tabs
   (testing "with leading hard tabs"
-    (let [result (hard-tabs (lines "\tHello"))]
+    (let [result (:errors (hard-tabs {} (lines "\tHello")))]
       (is (= (count result) 1))
       (is (= (-> result first :line) 1))))
 
   (testing "with trailing hard tabs"
-    (let [result (hard-tabs (lines "Hello\t"))]
+    (let [result (:errors (hard-tabs {} (lines "Hello\t")))]
       (is (= (count result) 1))
       (is (= (-> result first :line) 1)))))
 
 (deftest test-trailing-whitespace
   (testing "with trailing spaces"
-    (let [result (trailing-whitespace (lines "Hello "))]
+    (let [result (:errors (trailing-whitespace {} (lines "Hello ")))]
       (is (= (count result) 1))
       (is (= (-> result first :line) 1))))
 
   (testing "with trailing hard tabs"
-    (let [result (trailing-whitespace (lines "Hello\t"))]
+    (let [result (:errors (trailing-whitespace {} (lines "Hello\t")))]
       (is (= (count result) 1))
       (is (= (-> result first :line) 1)))))
 
 (deftest test-long-lines
   (testing "with exactly 80 letters"
-    (let [result (long-lines (lines (letters 80)))]
+    (let [result (:errors (long-lines {} (lines (letters 80))))]
       (is (= (count result) 0))))
 
+  (testing "newline not counted as char in max"
+    (let [result (:errors (long-lines {} (lines (str (letters 80) "\n"))))]
+      (is (= (count result) 0))))
+
+  (testing "warnings on line-width options"
+    (let [{warnings :warnings
+           errors :errors} (long-lines {:warn-line-width 68}
+                                       (lines (letters 69)))]
+      (is (= (count warnings) 1))
+      (is (= (count errors) 0))))
+
   (testing "with more than 80 letters"
-    (let [result (long-lines (lines (letters 81)))]
+    (let [result (:errors (long-lines {} (lines (letters 81))))]
       (is (= (count result) 1))
       (is (= (-> result first :line) 1)))))
 
 (deftest test-missing-final-newline?
   (testing "with a newline at the end of the file"
-    (let [result (missing-final-newline? {:path "foo.txt" :content "Hello\n"})]
-      (is (false? result))))
+    (let [result (missing-final-newline? {} {:path "foo.txt"
+                                             :content "Hello\n"})]
+      (is (false? (:errors result)))))
 
   (testing "with no new line at the end of the file"
-    (let [result (missing-final-newline? {:path "foo.txt" :content "Hello"})]
-      (is (true? result)))))
+    (let [result (missing-final-newline? {} {:path "foo.txt" :content "Hello"})]
+      (is (true? (:errors result))))))

--- a/test/whitespace_linter/lint_test.clj
+++ b/test/whitespace_linter/lint_test.clj
@@ -4,7 +4,7 @@
             [whitespace-linter.test.fixture :as fixture]))
 
 (deftest test-validate-files
-  (let [results (validate-files (fixture/load-fixtures))
+  (let [{results :errors} (validate-files {} (fixture/load-fixtures))
         result (first results)
         file (first result)
         errors (last result)]
@@ -18,3 +18,29 @@
          :long-lines #{1})
 
     (is (:missing-final-newline errors))))
+
+
+(deftest test-validate-files-with-warnings
+  (let [{err-results :errors
+         warn-results :warnings} (validate-files {:warn-line-width 68}
+                                                 (fixture/load-fixtures))
+        result (first err-results)
+        file (first result)
+        errors (last result)
+        warning (first warn-results)
+        warn-file (first warning)
+        warnings (last warning)]
+
+    (is (= (count err-results) 1))
+    (is (= file (fixture/fixture-file "messy.txt")))
+
+    (are [k line-numbers] (= (k errors) line-numbers)
+      :hard-tabs #{3 4 5}
+      :trailing-whitespace #{3}
+      :long-lines #{1})
+
+    (is (:missing-final-newline errors))
+
+    (is (= (count warn-results) 1))
+    (is (= warn-file (fixture/fixture-file "tidy.txt")))
+    (is (= (:long-lines warnings) #{2}))))


### PR DESCRIPTION
@jcf , some things we were thinking about WRT this linter.  

1) Currently the newline is counted as one of the 80 chars in the line-limit.  I don't think I've seen this before and most IDE's (including mine) won't highlight on that whitespace.  I just trimmed the newline off the line count when we check. Alternatively, that could be toggled via an option passed in.

2) speaking of options, we wanted the ability to warn on certain conditions rather than hard error.  Ideally we would always keep things at 80 chars, but the hard limit makes for some odd formatting choices in some rare edge cases.  I threw together the ability to pass in some options and propagate warnings as well as errors with warnings not returning a non zero exit code.  I added the ability to all checks, but only implemented new options for the line lengths specifically.  This would give us the ability to evaluate lines slightly over the "soft limit" via the warning, and still have a hard stop for egregious line-length overruns.   

default behavior remains as is with the caveats that globs would be passed in via the `:path` option rather than the first arg to the linter and the 81st new line char not resulting in a non 0 exit status. 

This is thrown together rather quickly just to see if it was easily doable.  If the additions I have proposed here are agreeable, I can clean it up a bit. 

